### PR TITLE
Update nokogiri version

### DIFF
--- a/embulk-parser-xml.gemspec
+++ b/embulk-parser-xml.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "nokogiri", "~> 1.8.2"
+  spec.add_dependency "nokogiri", "~> 1.10.1"
   spec.add_development_dependency "bundler", "~> 1.0"
   spec.add_development_dependency 'embulk', ['>= 0.9.7']
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Experienced lots of java heap memory errors when trying to import large xml file.
Probably related to https://github.com/sparklemotion/nokogiri/issues/1749

Updated nokogiri to latest and seems that memory issues are gone.
